### PR TITLE
fix: resolve CI failures on main branch

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/integration-tests'],


### PR DESCRIPTION
Fixes CI test failures reported in issue #2.

The Jest configuration files were using ES module syntax but the project is configured for CommonJS, causing Jest to fail loading the configs.

**Changes:**
- Converted jest.config.js from export default to module.exports
- Converted jest.integration.config.js from export default to module.exports

**Test Results:**
- Unit tests: 2/2 passing
- Integration tests: 10/10 passing
- Build: successful
- Linting: no issues

Generated with [Claude Code](https://claude.ai/code)