### PR TITLE
fix: resolve Jest configuration and timeout issues causing CI failure

### DIFF
--- a/integration-tests/subjects/aws/dynamodb/dynamodb-cloud-subject.integration.test.ts
+++ b/integration-tests/subjects/aws/dynamodb/dynamodb-cloud-subject.integration.test.ts
@@ -25,14 +25,14 @@ describe('DynamoDB CloudSubject Integration Tests', () => {
     // Start DynamoDB Local container
     dynamoDBContainer = new DynamoDBLocalContainer();
     await dynamoDBContainer.start();
-  });
+  }, 30000);
 
   afterAll(async () => {
     // Stop DynamoDB Local container
     if (dynamoDBContainer) {
       await dynamoDBContainer.stop();
     }
-  });
+  }, 30000);
 
   beforeEach(() => {
     // Get current test name to use as stream name

--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
         ],
         "coverageDirectory": "coverage-integration",
         "maxWorkers": 1,
-        "detectOpenHandles": true,
-        "testTimeout": 30000
+        "detectOpenHandles": true
       }
     ]
   }


### PR DESCRIPTION
Fixes CI failure on main branch (commit 37899a6)

## Changes
- Remove invalid `testTimeout` configuration option from Jest config
- Add 30s timeout to beforeAll/afterAll hooks in DynamoDB integration tests
- Keep command line `--testTimeout=30000` flags for proper timeout configuration

## Test Results
All tests now pass: ✅ 11/11 tests (3 unit + 8 integration)

Fixes #13

Generated with [Claude Code](https://claude.ai/code)