### PR TITLE
fix: remove unused DeleteCommand import

### DIFF
--- a/src/providers/aws/dynamodb/dynamodb-provider.ts
+++ b/src/providers/aws/dynamodb/dynamodb-provider.ts
@@ -3,7 +3,6 @@ import {
   DynamoDBDocumentClient,
   PutCommand,
   QueryCommand,
-  DeleteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { CloudProvider, CloudProviderOptions } from '../../cloud-provider';
 import { from, defer, of } from 'rxjs';


### PR DESCRIPTION
Fixes CI Quality Checks failure on commit ac3b208.

Removes unused DeleteCommand import from DynamoDB provider that was causing ESLint CI failure. The import was likely left over from recent refactoring that moved typing to provider level.

Closes #15

Generated with [Claude Code](https://claude.ai/code)